### PR TITLE
Add chart export functionality & light theme support / 添加图表导出功能和亮色主题支持

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,6 +39,7 @@
                 "@types/node": "^20.14.1",
                 "@types/react": "^18.3.3",
                 "@types/react-dom": "^18.3.0",
+                "cross-env": "^10.1.0",
                 "eslint": "^8.57.0",
                 "prettier": "^3.3.0",
                 "react-scripts": "^5.0.1",
@@ -2625,6 +2626,12 @@
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
             "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
+        },
+        "node_modules/@epic-web/invariant": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+            "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+            "dev": true
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
@@ -7539,10 +7546,27 @@
                 "node": ">=10"
             }
         },
+        "node_modules/cross-env": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+            "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+            "dev": true,
+            "dependencies": {
+                "@epic-web/invariant": "^1.0.0",
+                "cross-spawn": "^7.0.6"
+            },
+            "bin": {
+                "cross-env": "dist/bin/cross-env.js",
+                "cross-env-shell": "dist/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "dependencies": {
                 "path-key": "^3.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
         "redux-query-sync": "^0.1.10"
     },
     "scripts": {
-        "start": "REACT_APP_USE_LAMBDA=true react-scripts start",
+        "start": "cross-env REACT_APP_USE_LAMBDA=true react-scripts start",
         "start-local": "react-scripts start",
         "build": "react-scripts build",
         "test": "react-scripts test",
@@ -60,6 +60,7 @@
         "@types/node": "^20.14.1",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
+        "cross-env": "^10.1.0",
         "eslint": "^8.57.0",
         "prettier": "^3.3.0",
         "react-scripts": "^5.0.1",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="en" style="color-scheme: dark">
+<html lang="en" style="color-scheme: light">
     <head>
         <meta charset="utf-8" />
         <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="theme-color" content="#000000" />
+        <meta name="theme-color" content="#ffffff" />
         <meta name="description" content="Web site created using create-react-app" />
         <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
         <!--

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -84,6 +84,7 @@ export const {
     useGetCountsQuery,
     useGetIdentifiersQuery,
     useGetResultQuery,
+    useLazyGetResultQuery,
     useGetMWASQuery,
     useLazyGetSummaryTextQuery,
     useLazyGetHypothesisQuery,

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -67,7 +67,7 @@ const App = () => {
         /* set to -240 to offset Sidebar "drawerWidth" in SidePanel.tsx */
         marginLeft: `-240px`,
         marginRight: `0px`,
-        backgroundColor: 'rgba(29, 30, 32, 0.6)',
+        backgroundColor: 'transparent',
     });
 
     const showOnboardingMessage = () => {

--- a/frontend/src/app/Footer.tsx
+++ b/frontend/src/app/Footer.tsx
@@ -10,8 +10,6 @@ const Footer = () => {
             display='flex'
             justifyContent='flex-start'
             alignItems='flex-start'
-            bgcolor='black'
-            color='white'
             width={'100%'}
             pt={'5%'}
             pr={'10%'}

--- a/frontend/src/app/Toolbar.tsx
+++ b/frontend/src/app/Toolbar.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { toggleSidebar, selectSidebarOpen } from './slice.ts';
-import { toggleChat, selectChatOpen } from '../features/LLM/slice.ts';
+import { toggleSidebar, selectSidebarOpen, toggleDarkMode, selectDarkMode } from './slice.ts';
 import { useTheme } from '@mui/material/styles';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+import LightModeIcon from '@mui/icons-material/LightMode';
+import { toggleChat, selectChatOpen } from '../features/LLM/slice.ts';
 
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
@@ -18,8 +20,10 @@ const AppToolbar = () => {
     const dispatch = useDispatch();
     const isFilterOpen = useSelector(selectSidebarOpen);
     const isChatOpen = useSelector(selectChatOpen);
+    const darkMode = useSelector(selectDarkMode);
     const theme = useTheme();
     const drawerWidth = 100;
+    const iconBtnBg = darkMode ? 'rgba(86, 86, 86, 0.7)' : 'rgba(0, 0, 0, 0.08)';
 
     const getAppBarStyles = () => ({
         'transition': theme.transitions.create(['margin', 'width'], {
@@ -63,7 +67,7 @@ const AppToolbar = () => {
                             onClick={handleFilterClick}
                             edge='start'
                             sx={{
-                                backgroundColor: 'rgba(86, 86, 86, 0.7)',
+                                backgroundColor: iconBtnBg,
                                 mr: 2,
                                 ml: '3%',
                             }}
@@ -86,7 +90,7 @@ const AppToolbar = () => {
                             onClick={handleChatClick}
                             edge='start'
                             sx={{
-                                backgroundColor: 'rgba(86, 86, 86, 0.7)',
+                                backgroundColor: iconBtnBg,
                                 position: 'absolute',
                                 right: '3%',
                                 ...(isChatOpen && { display: 'none' }),
@@ -96,6 +100,19 @@ const AppToolbar = () => {
                         </IconButton>
                     </Tooltip>
                 ) : null}
+                <Tooltip title={darkMode ? 'Light mode' : 'Dark mode'} placement='bottom'>
+                    <IconButton
+                        onClick={() => dispatch(toggleDarkMode())}
+                        edge='start'
+                        sx={{
+                            backgroundColor: iconBtnBg,
+                            position: 'absolute',
+                            right: isChatOpen ? '80px' : '80px',
+                        }}
+                    >
+                        {darkMode ? <LightModeIcon fontSize='medium' /> : <DarkModeIcon fontSize='medium' />}
+                    </IconButton>
+                </Tooltip>
             </Toolbar>
         </AppBar>
     );

--- a/frontend/src/app/slice.ts
+++ b/frontend/src/app/slice.ts
@@ -27,7 +27,7 @@ const appSlice = createSlice({
             ecology: 'simple',
             host: 'simple',
         },
-        darkMode: true,
+        darkMode: false,
         palmprintOnly: true,
     },
     reducers: {

--- a/frontend/src/common/BarPlot.tsx
+++ b/frontend/src/common/BarPlot.tsx
@@ -1,7 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import ReactEcharts from 'echarts-for-react';
+import ExportButton from '../common/ExportButton.tsx';
+import { exportEChartsToPNG } from '../common/utils/exportHelpers.ts';
 
-const BarPlot = ({ plotData = {}, styles = {}, onEvents = {}, imagePath = "" }) => {
+const BarPlot = ({ plotData = {}, styles = {}, onEvents = {}, imagePath = "", title = "" }) => {
+    const echartsRef = useRef<any>(null);
     const [imageDimensions, setImageDimensions] = useState({ width: 100, height: 100, padding: 20, maxCategoryLength: 0, loaded: false });
     const [options, setOptions] = useState({});
 
@@ -25,9 +28,6 @@ const BarPlot = ({ plotData = {}, styles = {}, onEvents = {}, imagePath = "" }) 
             const gridLeft = imageDimensions.loaded ? Math.max(imageDimensions.width + imageDimensions.padding + imageDimensions.maxCategoryLength, 150) : 150;
             const newOptions = {
                 backgroundColor: 'transparent',
-                textStyle: { color: 'white' },
-                subtextStyle: { color: 'white' },
-                legend: { textStyle: { color: 'white' } },
                 tooltip: {
                     trigger: 'axis',
                     axisPointer: { type: 'shadow' },
@@ -37,10 +37,23 @@ const BarPlot = ({ plotData = {}, styles = {}, onEvents = {}, imagePath = "" }) 
                     right: '4%',
                     bottom: '3%',
                     containLabel: true,
-                    borderColor: 'white',
                 },
                 ...plotData,
             };
+
+            if (title) {
+                newOptions.title = {
+                    text: title,
+                    textStyle: {
+                        color: '#333',
+                        fontSize: 14,
+                        fontWeight: 'normal',
+                        fontStyle: 'italic',
+                    },
+                    left: 0,
+                    top: 5,
+                };
+            }
 
             if (imageDimensions.loaded) {
                 newOptions.graphic = [
@@ -64,7 +77,19 @@ const BarPlot = ({ plotData = {}, styles = {}, onEvents = {}, imagePath = "" }) 
         initializeChart();
     }, [imagePath, imageDimensions.loaded, plotData]);
 
-    return <ReactEcharts option={options} style={styles} onEvents={onEvents} />;
+    return (
+        <div style={{ position: 'relative' }}>
+            <div style={{ position: 'absolute', right: 8, top: 8, zIndex: 10 }}>
+                <ExportButton
+                    onClick={() => {
+                        const instance = echartsRef.current?.getEchartsInstance();
+                        if (instance) exportEChartsToPNG(instance, 'bar-plot.png');
+                    }}
+                />
+            </div>
+            <ReactEcharts ref={echartsRef} option={options} style={styles} onEvents={onEvents} />
+        </div>
+    );
 };
 
 export default BarPlot;

--- a/frontend/src/common/ExportButton.tsx
+++ b/frontend/src/common/ExportButton.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import DownloadIcon from '@mui/icons-material/Download';
+
+interface ExportButtonProps {
+    onClick: () => void;
+    tooltip?: string;
+    size?: 'small' | 'medium' | 'large';
+}
+
+const ExportButton = ({ onClick, tooltip = 'Download', size = 'small' }: ExportButtonProps) => (
+    <Tooltip title={tooltip}>
+        <IconButton onClick={onClick} size={size} sx={{ color: '#666' }}>
+            <DownloadIcon fontSize={size} />
+        </IconButton>
+    </Tooltip>
+);
+
+export default ExportButton;

--- a/frontend/src/common/HistogramPlot.tsx
+++ b/frontend/src/common/HistogramPlot.tsx
@@ -1,20 +1,12 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import ReactEcharts from 'echarts-for-react';
+import ExportButton from '../common/ExportButton.tsx';
+import { exportEChartsToPNG } from '../common/utils/exportHelpers.ts';
 
 const HistogramPlot = ({ plotData = {}, styles = {}, onEvents = {} }) => {
+    const echartsRef = useRef<any>(null);
     const defaultConfig = {
         backgroundColor: 'transparent',
-        textStyle: {
-            color: 'white',
-        },
-        subtextStyle: {
-            color: 'white',
-        },
-        legend: {
-            textStyle: {
-                color: 'white',
-            },
-        },
         tooltip: {
             trigger: 'item',
             axisPointer: {
@@ -39,7 +31,19 @@ const HistogramPlot = ({ plotData = {}, styles = {}, onEvents = {} }) => {
         obj.barWidth = '101%';
     });
 
-    return <ReactEcharts option={options} style={styles} onEvents={onEvents} />;
+    return (
+        <div style={{ position: 'relative' }}>
+            <div style={{ position: 'absolute', right: 8, top: 8, zIndex: 10 }}>
+                <ExportButton
+                    onClick={() => {
+                        const instance = echartsRef.current?.getEchartsInstance();
+                        if (instance) exportEChartsToPNG(instance, 'histogram-plot.png');
+                    }}
+                />
+            </div>
+            <ReactEcharts ref={echartsRef} option={options} style={styles} onEvents={onEvents} />
+        </div>
+    );
 };
 
 export default HistogramPlot;

--- a/frontend/src/common/MapLibreDeckGLMap.tsx
+++ b/frontend/src/common/MapLibreDeckGLMap.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import MdCopyAll from '@mui/icons-material/CopyAll';
 import MdOpenInNew from '@mui/icons-material/OpenInNew';
 import { deflate } from 'pako';
 import { isSimpleLayout } from '../common/utils/plotHelpers.ts';
 import { truncate } from '../common/utils/textFormatting.ts';
+import ExportButton from '../common/ExportButton.tsx';
+import { exportCanvasToPNG } from '../common/utils/exportHelpers.ts';
 import {
     WWF_BIOMES,
     AMAZON_LOCATION_API_KEY,
@@ -461,6 +463,7 @@ const MapLibreDeckGLMap = ({ identifiers, layout, palmprintOnly, style = {} }) =
     };
 
     const mapRef = useRef(null);
+    const mlglMapRef = useRef<any>(null);
     const [attributeName, setAttributeName] = useState('');
     const [attributeValue, setAttributeValue] = useState('');
     const [biomeID, setBiomeID] = useState('');
@@ -506,6 +509,7 @@ const MapLibreDeckGLMap = ({ identifiers, layout, palmprintOnly, style = {} }) =
                     AMAZON_LOCATION_API_KEY,
                 zoom: 0.8,
             });
+            mlglMapRef.current = mlglMap;
             mlglMap.dragRotate.disable();
             mlglMap.getCanvas().style.cursor = 'crosshair';
 
@@ -586,6 +590,11 @@ const MapLibreDeckGLMap = ({ identifiers, layout, palmprintOnly, style = {} }) =
         else setCountryRegionID('');
     }, [biomeID, countryID]);
 
+    const handleExport = useCallback(() => {
+        const canvas = mlglMapRef.current?.getCanvas();
+        if (canvas) exportCanvasToPNG(canvas, 'ecology-map.png');
+    }, []);
+
     const MapLibreDeckGLMapModeButton: any = ({ onClick, selected, text }) => (
         <div
             onClick={onClick}
@@ -609,7 +618,7 @@ const MapLibreDeckGLMap = ({ identifiers, layout, palmprintOnly, style = {} }) =
         <div style={style}>
             <div style={{ alignItems: 'flex-end', display: 'flex', padding: '0 6px 0 6px' }}>
                 <div style={{ flex: '1 0' }}>
-                    <div style={{ color: '#EEE', fontSize: '16px', fontWeight: 700 }}>
+                    <div style={{ color: '#333', fontSize: '16px', fontWeight: 700 }}>
                         {'Showing ' +
                             siteCount.toLocaleString() +
                             ' contigs, representing ' +
@@ -649,6 +658,7 @@ const MapLibreDeckGLMap = ({ identifiers, layout, palmprintOnly, style = {} }) =
                             selected={mapMode === 'SAMPLES'}
                             text='Samples'
                         />
+                        <ExportButton onClick={handleExport} />
                     </div>
                 )}
             </div>
@@ -1238,7 +1248,7 @@ const MapLibreDeckGLMap = ({ identifiers, layout, palmprintOnly, style = {} }) =
 const MapLibreDeckGLMapCopyButton = ({ ...props }) => (
     <MdCopyAll
         style={{
-            color: '#FFF',
+            color: '#333',
             cursor: 'pointer',
             fontSize: '16px',
             userSelect: 'none',
@@ -1250,7 +1260,7 @@ const MapLibreDeckGLMapURLButton = ({ fontSize, ...props }) => {
     if (!fontSize) fontSize = '18px';
 
     return (
-        <a style={{ color: '#FFF', userSelect: 'none' }} target='_blank' {...props}>
+        <a style={{ color: '#333', userSelect: 'none' }} target='_blank' {...props}>
             <MdOpenInNew style={{ fontSize, verticalAlign: 'bottom' }} />
         </a>
     );

--- a/frontend/src/common/NetworkPlot.tsx
+++ b/frontend/src/common/NetworkPlot.tsx
@@ -1,9 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import cytoscape from 'cytoscape';
 import fcose from 'cytoscape-fcose';
 
 import CytoscapeComponent from 'react-cytoscapejs';
 import Box from '@mui/material/Box';
+import ExportButton from '../common/ExportButton.tsx';
+import { exportCytoscapeToPNG } from '../common/utils/exportHelpers.ts';
 
 cytoscape.use(fcose);
 
@@ -35,7 +37,7 @@ const NetworkPlot = ({ plotData = [], onNodeClick, onEdgeClick }) => {
             style: {
                 backgroundColor: 'data(color)',
                 label: 'data(label)',
-                color: 'white',
+                color: '#333',
                 shape: 'round-hexagon',
                 opacity: 1,
                 width: 35,
@@ -46,8 +48,8 @@ const NetworkPlot = ({ plotData = [], onNodeClick, onEdgeClick }) => {
         {
             selector: 'node[type="run"]',
             style: {
-                backgroundColor: 'white',
-                color: 'white',
+                backgroundColor: '#ccc',
+                color: '#333',
                 shape: 'ellipse',
                 opacity: 0.7,
                 width: 20,
@@ -164,13 +166,20 @@ const NetworkPlot = ({ plotData = [], onNodeClick, onEdgeClick }) => {
         },
     ];
 
+    const handleExport = useCallback(() => {
+        if (cy) exportCytoscapeToPNG(cy, 'network-plot.png');
+    }, [cy]);
+
     return (
-        <Box>
+        <Box sx={{ position: 'relative' }}>
+            <Box sx={{ position: 'absolute', right: 8, top: 8, zIndex: 10 }}>
+                <ExportButton onClick={handleExport} />
+            </Box>
             <CytoscapeComponent
                 cy={setCy}
                 stylesheet={stylesheet}
                 elements={plotData}
-                style={{ width: '100%', height: '75vh', background: 'rgba(29, 30, 32, 0.6)' }}
+                style={{ width: '100%', height: '75vh', background: 'var(--cytoscape-bg, #f5f5f5)' }}
                 layout={layouts[0]}
                 minZoom={0.1}
                 maxZoom={2}

--- a/frontend/src/common/PagedTable.tsx
+++ b/frontend/src/common/PagedTable.tsx
@@ -10,6 +10,8 @@ import TableRow from '@mui/material/TableRow';
 import TableSortLabel from '@mui/material/TableSortLabel';
 import Paper from '@mui/material/Paper';
 import { visuallyHidden } from '@mui/utils';
+import ExportButton from '../common/ExportButton.tsx';
+import { exportToCSV } from '../common/utils/exportHelpers.ts';
 
 function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
     if (b[orderBy] < a[orderBy]) {
@@ -104,11 +106,12 @@ function EnhancedTableHead(props: EnhancedTableProps) {
     );
 }
 
-const PagedTable = ({ page = 0, rows = [], headers = [], total, onPageChange, pageRows = 10 }) => {
+const PagedTable = ({ page = 0, rows = [], headers = [], total, onPageChange, pageRows = 10, allRows = null, onExportAll = null }) => {
     const [order, setOrder] = React.useState<Order>('asc');
     const [orderBy, setOrderBy] = React.useState('calories');
     const [dense, setDense] = React.useState(true);
     const [rowsPerPage, setRowsPerPage] = React.useState(pageRows);
+    const [exporting, setExporting] = React.useState(false);
 
     const onRequestSort = (event: React.MouseEvent<unknown>, property: keyof Data) => {
         const isAsc = orderBy === property && order === 'asc';
@@ -124,9 +127,33 @@ const PagedTable = ({ page = 0, rows = [], headers = [], total, onPageChange, pa
         [order, orderBy, page, rowsPerPage, rows],
     );
 
+    const hasAllData = allRows && allRows.length > 0;
+    const hasExportAllHandler = !!onExportAll;
+
+    const handleExport = React.useCallback(async () => {
+        if (onExportAll) {
+            setExporting(true);
+            try {
+                await onExportAll();
+            } finally {
+                setExporting(false);
+            }
+        } else if (hasAllData) {
+            exportToCSV(allRows, headers, 'table-export.csv');
+        } else {
+            exportToCSV(rows, headers, 'table-export.csv');
+        }
+    }, [rows, headers, allRows, hasAllData, onExportAll]);
+
     return (
         <Box sx={{ width: '100%', overflow: 'hidden' }}>
-            <Paper sx={{ overflow: 'hidden' }}>
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 0.5 }}>
+                <ExportButton
+                    onClick={handleExport}
+                    tooltip={exporting ? 'Downloading...' : hasExportAllHandler || hasAllData ? 'Download all as CSV' : 'Download current page as CSV'}
+                />
+            </Box>
+            <Paper sx={{ overflow: 'hidden', boxShadow: 'none', backgroundImage: 'none' }}>
                 <TableContainer>
                     <Table aria-labelledby='tableTitle' size={dense ? 'small' : 'medium'}>
                         <EnhancedTableHead

--- a/frontend/src/common/PolarBarPlot.tsx
+++ b/frontend/src/common/PolarBarPlot.tsx
@@ -1,23 +1,15 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import ReactEcharts from 'echarts-for-react';
+import ExportButton from '../common/ExportButton.tsx';
+import { exportEChartsToPNG } from '../common/utils/exportHelpers.ts';
 
-const PolarBarPlot = ({ plotData = {}, styles = {}, onEvents = {} }) => {
+const PolarBarPlot = ({ plotData = {}, styles = {}, onEvents = {}, title = "" }) => {
+    const echartsRef = useRef<any>(null);
     const defaultConfig = {
         backgroundColor: 'transparent',
-        textStyle: {
-            color: 'white',
-        },
-        subtextStyle: {
-            color: 'white',
-        },
         grid: {
             left: '-1%',
             borderColor: 'transparent',
-        },
-        legend: {
-            textStyle: {
-                color: 'white',
-            },
         },
         tooltip: {
             trigger: 'axis',
@@ -39,7 +31,7 @@ const PolarBarPlot = ({ plotData = {}, styles = {}, onEvents = {} }) => {
         Math.max(...plotData.dataset.source.map((d) => d.target), ...plotData.dataset.source.map((d) => d.control)) *
         1.1;
 
-    const options = {
+    const options: any = {
         ...defaultConfig,
         ...plotData,
         series: [
@@ -60,7 +52,33 @@ const PolarBarPlot = ({ plotData = {}, styles = {}, onEvents = {} }) => {
         },
     };
 
-    return <ReactEcharts option={options} style={styles} onEvents={onEvents} />;
+    if (title) {
+        options.title = {
+            text: title,
+            textStyle: {
+                color: '#333',
+                fontSize: 14,
+                fontWeight: 'normal',
+                fontStyle: 'italic',
+            },
+            left: 0,
+            top: 5,
+        };
+    }
+
+    return (
+        <div style={{ position: 'relative' }}>
+            <div style={{ position: 'absolute', right: 8, top: 8, zIndex: 10 }}>
+                <ExportButton
+                    onClick={() => {
+                        const instance = echartsRef.current?.getEchartsInstance();
+                        if (instance) exportEChartsToPNG(instance, 'polar-bar-plot.png');
+                    }}
+                />
+            </div>
+            <ReactEcharts ref={echartsRef} option={options} style={styles} onEvents={onEvents} />
+        </div>
+    );
 };
 
 export default PolarBarPlot;

--- a/frontend/src/common/ScatterPlot.tsx
+++ b/frontend/src/common/ScatterPlot.tsx
@@ -1,26 +1,17 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import ReactEcharts from 'echarts-for-react';
+import ExportButton from '../common/ExportButton.tsx';
+import { exportEChartsToPNG } from '../common/utils/exportHelpers.ts';
 
 const ScatterPlot = ({ plotData = {}, styles = {}, onEvents = {} }) => {
+    const echartsRef = useRef<any>(null);
     const defaultConfig = {
         backgroundColor: 'transparent',
-        textStyle: {
-            color: 'white',
-        },
-        subtextStyle: {
-            color: 'white',
-        },
-        legend: {
-            textStyle: {
-                color: 'white',
-            },
-        },
         grid: {
             left: '3%',
             right: '4%',
             bottom: '3%',
             containLabel: true,
-            borderColor: 'white',
         },
         xAxis: {
             type: 'value',
@@ -36,7 +27,19 @@ const ScatterPlot = ({ plotData = {}, styles = {}, onEvents = {} }) => {
         ...plotData,
     };
 
-    return <ReactEcharts option={options} style={styles} onEvents={onEvents} />;
+    return (
+        <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+            <div style={{ position: 'absolute', right: 8, top: 8, zIndex: 10 }}>
+                <ExportButton
+                    onClick={() => {
+                        const instance = echartsRef.current?.getEchartsInstance();
+                        if (instance) exportEChartsToPNG(instance, 'scatter-plot.png');
+                    }}
+                />
+            </div>
+            <ReactEcharts ref={echartsRef} option={options} style={{ width: '100%', height: '100%', ...styles }} onEvents={onEvents} />
+        </div>
+    );
 };
 
 export default ScatterPlot;

--- a/frontend/src/common/SearchBar.tsx
+++ b/frontend/src/common/SearchBar.tsx
@@ -26,6 +26,8 @@ const SearchBar = ({ query, setQuery, placeholder = 'Search' }) => {
                 alignItems: 'center',
                 height: 40,
                 flex: 1,
+                boxShadow: 'none',
+                backgroundImage: 'none',
             }}
         >
             <InputBase

--- a/frontend/src/common/VirtualizedTable.tsx
+++ b/frontend/src/common/VirtualizedTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -6,9 +6,11 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import Paper from '@mui/material/Paper';
 import Checkbox from '@mui/material/Checkbox';
+import Box from '@mui/material/Box';
 import { TableVirtuoso, TableComponents } from 'react-virtuoso';
+import ExportButton from '../common/ExportButton.tsx';
+import { exportToCSV } from '../common/utils/exportHelpers.ts';
 
 interface Data {
     name: string;
@@ -37,8 +39,12 @@ const defaultColumns: ColumnData[] = [
 ];
 
 const VirtuosoTableComponents: TableComponents<Data> = {
-    Scroller: React.forwardRef<HTMLDivElement>((props, ref) => (
-        <TableContainer component={Paper} {...props} ref={ref} />
+    Scroller: React.forwardRef<HTMLDivElement>((props: any, ref) => (
+        <TableContainer
+            {...props}
+            ref={ref}
+            sx={{ boxShadow: 'none', backgroundImage: 'none', backgroundColor: 'transparent', ...(props.sx || {}) }}
+        />
     )),
     Table: (props) => <Table {...props} sx={{ borderCollapse: 'separate', tableLayout: 'fixed' }} />,
     TableHead,
@@ -54,7 +60,7 @@ const VirtualizedTable = ({ rows = [], columns = defaultColumns, onRowClick, sea
         const isChecked = !disableSelectAll(rows) && rows.length > 0 && rows.every((row) => row.selected);
         return (
             <TableRow>
-                <TableCell padding='checkbox' sx={{ width: 8, pl: 2, backgroundColor: '#121212' }}>
+                <TableCell padding='checkbox' sx={{ width: 8, pl: 2, backgroundColor: 'background.paper' }}>
                     <Checkbox
                         color='primary'
                         checked={isChecked}
@@ -153,15 +159,25 @@ const VirtualizedTable = ({ rows = [], columns = defaultColumns, onRowClick, sea
         sortRowsBySelected(rows);
     }, [rows.length]);
 
+    const columnKeys = columns.map((c) => c.dataKey as string);
+    const handleExport = useCallback(() => {
+        exportToCSV(rows, columnKeys, 'table-export.csv');
+    }, [rows, columnKeys]);
+
     return (
-        <Paper style={{ height: '75vh', width: '100%' }}>
+        <Box sx={{ position: 'relative' }}>
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 0.5 }}>
+                <ExportButton onClick={handleExport} tooltip="Download CSV" />
+            </Box>
+            <Box sx={{ height: '75vh', width: '100%' }}>
             <TableVirtuoso
                 data={rows}
                 components={VirtuosoTableComponents}
                 fixedHeaderContent={() => fixedHeaderContent(columns, rows, onSelectAllClick)}
                 itemContent={rowContent}
             />
-        </Paper>
+            </Box>
+        </Box>
     );
 };
 

--- a/frontend/src/common/utils/exportHelpers.ts
+++ b/frontend/src/common/utils/exportHelpers.ts
@@ -1,0 +1,50 @@
+const triggerDownload = (url: string, filename: string) => {
+    const link = document.createElement('a');
+    link.download = filename;
+    link.href = url;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+};
+
+export const exportEChartsToPNG = (instance: any, filename: string) => {
+    const url = instance.getDataURL({
+        type: 'png',
+        pixelRatio: 6,
+        backgroundColor: '#FFFFFF',
+    });
+    triggerDownload(url, filename);
+};
+
+export const exportCytoscapeToPNG = (cy: any, filename: string) => {
+    const url = cy.png({
+        full: true,
+        bg: '#FFFFFF',
+    });
+    triggerDownload(url, filename);
+};
+
+export const exportCanvasToPNG = (canvas: HTMLCanvasElement, filename: string) => {
+    const url = canvas.toDataURL('image/png');
+    triggerDownload(url, filename);
+};
+
+export const exportToCSV = (rows: Record<string, any>[], headers: string[], filename: string) => {
+    const headerLine = headers.join(',');
+    const dataLines = rows.map((row) =>
+        headers
+            .map((h) => {
+                const val = row[h] ?? '';
+                const str = String(val);
+                return str.includes(',') || str.includes('"') || str.includes('\n')
+                    ? `"${str.replace(/"/g, '""')}"`
+                    : str;
+            })
+            .join(',')
+    );
+    const csv = [headerLine, ...dataLines].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    triggerDownload(url, filename);
+    URL.revokeObjectURL(url);
+};

--- a/frontend/src/features/LLM/Chat.tsx
+++ b/frontend/src/features/LLM/Chat.tsx
@@ -108,7 +108,7 @@ export const Chat = () => {
                         display: 'flex',
                         flexDirection: 'column',
                         justifyContent: 'space-between',
-                        backgroundColor: '#252427',
+                        backgroundColor: 'background.paper',
                         backgroundImage: 'unset',
                     },
                 }}
@@ -149,7 +149,7 @@ export const Chat = () => {
                         sx={{
                             '& .MuiInputBase-root': {
                                 borderRadius: 2,
-                                backgroundColor: '#484848',
+                                backgroundColor: 'action.hover',
                             },
                             '& .MuiOutlinedInput-root': {
                                 '& fieldset': {

--- a/frontend/src/features/LLM/GenerateButton.tsx
+++ b/frontend/src/features/LLM/GenerateButton.tsx
@@ -16,7 +16,7 @@ const GenerateButton = ({ onButtonClick, title }) => {
 
     return (
         <Tooltip title={title} placement='bottom'>
-            <IconButton style={{ backgroundColor: 'rgba(86, 86, 86, 0.4)' }} onClick={onClick}>
+            <IconButton sx={{ backgroundColor: 'action.hover' }} onClick={onClick}>
                 <BlurOnIcon
                     style={{
                         color: '#9be3ef',

--- a/frontend/src/features/LLM/GenerateHypothesis.tsx
+++ b/frontend/src/features/LLM/GenerateHypothesis.tsx
@@ -61,11 +61,10 @@ const GenerateHypothesis = ({ identifiers, selectedMetadata }) => {
                 {!isFetchingHypothesis && hypothesisTextIsNonEmpty() ? (
                     <Box
                         sx={{
-                            backgroundColor: '#484848',
+                            backgroundColor: 'action.hover',
                             p: 2,
                             borderRadius: 2,
                             overflow: 'auto',
-                            colorScheme: 'dark',
                             maxHeight: 300,
                         }}
                     >

--- a/frontend/src/features/LLM/GenerateSummary.tsx
+++ b/frontend/src/features/LLM/GenerateSummary.tsx
@@ -320,11 +320,10 @@ const GenerateSummary = ({ identifiers, dataType, palmprintOnly }) => {
                     {!isFetchingSummary && summaryTextIsNonEmpty() ? (
                         <Box
                             sx={{
-                                backgroundColor: '#484848',
+                                backgroundColor: 'action.hover',
                                 p: 2,
                                 borderRadius: 2,
                                 overflow: 'auto',
-                                colorScheme: 'dark',
                                 maxHeight: 300,
                                 scrollbarWidth: 'none',
                                 '&::-webkit-scrollbar': {

--- a/frontend/src/features/LLM/OnboardingChat.tsx
+++ b/frontend/src/features/LLM/OnboardingChat.tsx
@@ -112,11 +112,10 @@ const GlobalChat = () => {
         return (
             <Box
                 sx={{
-                    backgroundColor: 'rgba(72, 72, 72, 0.9)',
+                    backgroundColor: 'background.paper',
                     p: 2,
                     borderRadius: 2,
                     overflow: 'auto',
-                    colorScheme: 'dark',
                     display: 'flex',
                     flexDirection: 'column',
                     gap: 2,
@@ -190,7 +189,7 @@ const GlobalChat = () => {
                             'width': '50%',
                             '& .MuiInputBase-root': {
                                 borderRadius: 4,
-                                backgroundColor: '#2f2f2f',
+                                backgroundColor: 'action.hover',
                             },
                             '& .MuiOutlinedInput-root': {
                                 '& fieldset': {

--- a/frontend/src/features/Module/Host/HostLayout.tsx
+++ b/frontend/src/features/Module/Host/HostLayout.tsx
@@ -103,7 +103,7 @@ const HostLayout = ({ identifiers, sectionLayout, palmprintOnly }) => {
             if(tissueCountData){
                 imagePath = chooseFigure(tissueCountData.at(-1));
             }
-            return <BarPlot plotData={getBarPlotData(tissueCountData, maxRows, imagePath)} imagePath={imagePath}/>;
+            return <BarPlot plotData={getBarPlotData(tissueCountData, maxRows, imagePath)} imagePath={imagePath} title="Tissue"/>;
         }
         return getEmptyResultsMessage();
     };
@@ -115,7 +115,7 @@ const HostLayout = ({ identifiers, sectionLayout, palmprintOnly }) => {
 
         if (diseaseCountData && diseaseCountData.length > 0) {
             const maxRows = isSimpleLayout(sectionLayout) ? 9 : undefined;
-            return <BarPlot plotData={getBarPlotData(diseaseCountData, maxRows)} />;
+            return <BarPlot plotData={getBarPlotData(diseaseCountData, maxRows)} title="Disease"/>;
         }
         return getEmptyResultsMessage();
     };
@@ -127,7 +127,7 @@ const HostLayout = ({ identifiers, sectionLayout, palmprintOnly }) => {
 
         if (organismCountData && organismCountData.length > 0) {
             const maxRows = isSimpleLayout(sectionLayout) ? 9 : undefined;
-            return <BarPlot plotData={getBarPlotData(organismCountData, maxRows)} />;
+            return <BarPlot plotData={getBarPlotData(organismCountData, maxRows)} title="STAT Organism"/>;
         }
         return getEmptyResultsMessage();
     };
@@ -139,7 +139,7 @@ const HostLayout = ({ identifiers, sectionLayout, palmprintOnly }) => {
 
         if (sexCountData && sexCountData.length > 0) {
             const maxRows = isSimpleLayout(sectionLayout) ? 9 : undefined;
-            return <PolarBarPlot plotData={getBarPlotData(sexCountData, maxRows)} />;
+            return <PolarBarPlot plotData={getBarPlotData(sexCountData, maxRows)} title="Sex"/>;
         }
         return getEmptyResultsMessage();
     };
@@ -148,17 +148,11 @@ const HostLayout = ({ identifiers, sectionLayout, palmprintOnly }) => {
         <Box sx={{ display: 'flex', flexDirection: 'column', width: '100%', width: '80vw', maxWidth: 1500 }}>
             <Box sx={{ flex: 1, display: 'flex', width: '100%', mb: 2 }}>
                 <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', width: '100%', height: '100%' }}>
-                    <Typography variant='h6' sx={{ mt: 2, mb: 2 }}>
-                        {`Tissue`}
-                    </Typography>
                     {getTissuePlot()}
                 </Box>
             </Box>
             <Box sx={{ flex: 1, display: 'flex', width: '100%', mb: 2 }}>
                 <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', width: '100%', height: '100%' }}>
-                    <Typography variant='h6' sx={{ mt: 2, mb: 2 }}>
-                        {`Disease`}
-                    </Typography>
                     {getDiseasePlot()}
                 </Box>
             </Box>
@@ -166,17 +160,11 @@ const HostLayout = ({ identifiers, sectionLayout, palmprintOnly }) => {
             <>
                 <Box sx={{ flex: 1, display: 'flex', width: '100%', mb: 2 }}>
                     <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', width: '100%', height: '100%' }}>
-                        <Typography variant='h6' sx={{ mt: 2, mb: 2 }}>
-                            {`STAT Organism`}
-                        </Typography>
                         {getOrganismPlot()}
                     </Box>
                 </Box>
                 <Box sx={{ flex: 1, display: 'flex', width: '100%', mb: 2 }}>
                     <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', width: '100%', height: '100%' }}>
-                        <Typography variant='h6' sx={{ mt: 2, mb: 2 }}>
-                            {`Sex`}
-                        </Typography>
                         {getSexPlot()}
                     </Box>
                 </Box>

--- a/frontend/src/features/Module/Host/plotHelpers.ts
+++ b/frontend/src/features/Module/Host/plotHelpers.ts
@@ -52,6 +52,9 @@ export const getBarPlotData = (data, maxRows = undefined, imagePath="") => {
         },
         yAxis: {
             type: 'category',
+            axisTick: {
+                alignWithLabel: true,
+            },
             axisLabel: {
                 formatter: (value) => truncate(value, 20),
             },
@@ -72,7 +75,7 @@ export const getBarPlotData = (data, maxRows = undefined, imagePath="") => {
                 stack: 'total',
                 label: {
                     show: true,
-                    color: 'white',
+                    color: '#333',
                 },
                 emphasis: {
                     focus: 'series',
@@ -82,9 +85,6 @@ export const getBarPlotData = (data, maxRows = undefined, imagePath="") => {
         ],
         legend: {
             show: false,
-            textStyle: {
-                color: 'white',
-            },
         },
         dataZoom: dataZoom,
     };

--- a/frontend/src/features/Module/SRARun/TargetControlFigure.tsx
+++ b/frontend/src/features/Module/SRARun/TargetControlFigure.tsx
@@ -79,8 +79,20 @@ const TargetControlFigure = ({ identifiers, moduleKey, figureType, sectionLayout
         const maxRows = figureType === 'polar' ? 4 : isSimpleLayout(sectionLayout) ? 9 : undefined;
         const plotData = getTargetControlPlotData(targetCountData, controlCountData, activeCountKey, maxRows);
         let totalRuns = getTotalRuns(seriesName);
+        const countLabel = activeCountKey === 'gbp' ? ' (Gbp)' : activeCountKey === 'percent' ? ' (%)' : '';
         const filteredPlotData = {
             ...plotData,
+            title: {
+                text: `${seriesName} set${countLabel}${totalRuns ? ' (n = ' + totalRuns + ')' : ''}`,
+                textStyle: {
+                    color: '#333',
+                    fontSize: 14,
+                    fontWeight: 'normal',
+                    fontStyle: 'italic',
+                },
+                left: 0,
+                top: 5,
+            },
             legend: {
                 show: false,
                 selected: {
@@ -88,16 +100,13 @@ const TargetControlFigure = ({ identifiers, moduleKey, figureType, sectionLayout
                     Control: seriesName === 'Control',
                 },
                 textStyle: {
-                    color: 'white',
+                    color: '#333',
                 },
             },
         };
         if (figureType === 'polar') {
             return (
                 <Box sx={{ minWidth: 400 }}>
-                    <Typography variant='body2' sx={{ fontStyle: 'italic' }}>
-                        {`${seriesName} set ${totalRuns ? `(n = ${totalRuns})` : ''}`}
-                    </Typography>
                     <PolarBarPlot plotData={filteredPlotData} />
                 </Box>
             );
@@ -105,9 +114,6 @@ const TargetControlFigure = ({ identifiers, moduleKey, figureType, sectionLayout
         if (figureType === 'bar') {
             return (
                 <Box sx={{ minWidth: 400 }}>
-                    <Typography variant='body2' sx={{ position: 'absolute', fontStyle: 'italic' }}>
-                        {`${seriesName} set ${totalRuns ? `(n = ${totalRuns})` : ''}`}
-                    </Typography>
                     <BarPlot plotData={filteredPlotData} />
                 </Box>
             );

--- a/frontend/src/features/Module/SRARun/plotHelpers.ts
+++ b/frontend/src/features/Module/SRARun/plotHelpers.ts
@@ -135,7 +135,7 @@ export const getTargetControlPlotData = (
                 stack: 'total',
                 label: {
                     show: true,
-                    color: 'white',
+                    color: '#333',
                 },
                 emphasis: {
                     focus: 'series',
@@ -148,7 +148,7 @@ export const getTargetControlPlotData = (
                 stack: 'total',
                 label: {
                     show: true,
-                    color: 'white',
+                    color: '#333',
                 },
                 emphasis: {
                     focus: 'series',
@@ -201,7 +201,7 @@ export const getBioprojectSizePlotData = (controlRows = []) => {
         title: {
             text: 'BioProject size',
             textStyle: {
-                color: 'white',
+                color: '#333',
                 fontSize: 14,
                 fontWeight: 'normal',
                 fontStyle: 'italic',
@@ -220,7 +220,7 @@ export const getBioprojectSizePlotData = (controlRows = []) => {
                 stack: 'total',
                 label: {
                     show: false,
-                    color: 'white',
+                    color: '#333',
                 },
                 emphasis: {
                     focus: 'series',
@@ -278,7 +278,7 @@ export const getBioprojectTargetPercentagePlotData = (controlRows = [], targetRo
         title: {
             text: '% of BioProject in Target set',
             textStyle: {
-                color: 'white',
+                color: '#333',
                 fontSize: 14,
                 fontWeight: 'normal',
                 fontStyle: 'italic',
@@ -310,7 +310,7 @@ export const getBioprojectTargetPercentagePlotData = (controlRows = [], targetRo
                 stack: 'total',
                 label: {
                     show: false,
-                    color: 'white',
+                    color: '#333',
                 },
                 emphasis: {
                     focus: 'series',
@@ -362,7 +362,7 @@ export const getBioprojectSizeVsPercentagePlotData = (controlRows = [], targetRo
         title: {
             text: 'Runs per BioProject vs. BioProject runs in Target set (%)',
             textStyle: {
-                color: 'white',
+                color: '#333',
                 fontSize: 14,
                 fontWeight: 'normal',
                 fontStyle: 'italic',
@@ -400,7 +400,7 @@ export const getBioprojectSizeVsPercentagePlotData = (controlRows = [], targetRo
                 type: 'scatter',
                 label: {
                     show: false,
-                    color: 'white',
+                    color: '#333',
                 },
                 emphasis: {
                     focus: 'series',

--- a/frontend/src/features/Module/Virome/ViromeMWAS.tsx
+++ b/frontend/src/features/Module/Virome/ViromeMWAS.tsx
@@ -58,7 +58,7 @@ const ViromeMWAS = ({ identifiers, virusFamilies }) => {
         return (
             <ScatterPlot
                 plotData={getMWASScatterPlotData(data, activeMetadataType)}
-                styles={{ width: '55%', height: '70vh' }}
+                styles={{ width: '100%', height: '70vh' }}
                 onEvents={onEvents}
             />
         );
@@ -81,9 +81,6 @@ const ViromeMWAS = ({ identifiers, virusFamilies }) => {
     return (
         <Box sx={{ width: '100%', height: '100%' }}>
             <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                <Typography variant='h6' component={'div'} sx={{ flex: 1.2 }}>
-                    {`Metadata-wide association study (MWAS) `}
-                </Typography>
                 {identifiers && identifiers['bioproject'].single.length > 100 ? (
                     <Typography variant='h7' component={'div'} sx={{ mt: 2, flex: 1 }}>
                         {`Dataset is too large. Displaying partial results.`}
@@ -105,9 +102,11 @@ const ViromeMWAS = ({ identifiers, virusFamilies }) => {
                     mt: 2,
                 }}
             >
-                {isFetching ? renderPlaceholder() : data ? scatterPlot : null}
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                    {isFetching ? renderPlaceholder() : data ? scatterPlot : null}
+                </Box>
                 {selectedMetadata ? (
-                    <Box sx={{ mt: 2, width: '45%' }}>
+                    <Box sx={{ mt: 2, width: '45%', flexShrink: 0 }}>
                         {renderSearchBox()}
                         <hr />
                         <Box sx={{ mt: 2 }}>

--- a/frontend/src/features/Module/Virome/ViromeSummaryTable.tsx
+++ b/frontend/src/features/Module/Virome/ViromeSummaryTable.tsx
@@ -286,6 +286,7 @@ const ViromeSummaryTable = ({ activeModule, selectedItem, onClose, rows, maxWidt
                     rows={getPagedRows()}
                     headers={Object.keys(filteredRows[0])}
                     pageRows={getRowsPerPage()}
+                    allRows={filteredRows}
                 />
             </Box>
         );
@@ -303,7 +304,7 @@ const ViromeSummaryTable = ({ activeModule, selectedItem, onClose, rows, maxWidt
                 flexDirection: 'column',
                 width: '95%',
                 height: '100%',
-                backgroundColor: 'rgba(86, 86, 86, 0.6)',
+                backgroundColor: 'background.paper',
                 borderRadius: 2,
                 padding: 1.5,
             }}

--- a/frontend/src/features/Module/Virome/plotHelpers.ts
+++ b/frontend/src/features/Module/Virome/plotHelpers.ts
@@ -196,13 +196,13 @@ export const getViromeScatterPlotData = (rows = []) => {
             right: '6%',
             bottom: '6%',
             containLabel: true,
-            borderColor: 'white',
+            borderColor: '#ccc',
         },
         title: {
             show: true,
             text: '   Virome Component Summary',
             textStyle: {
-                color: 'white',
+                color: '#333',
                 fontSize: 14,
                 fontWeight: 'normal',
                 fontStyle: 'italic',
@@ -230,7 +230,7 @@ export const getViromeScatterPlotData = (rows = []) => {
                 type: 'scatter',
                 label: {
                     show: false,
-                    color: 'white',
+                    color: '#333',
                 },
                 emphasis: {
                     focus: 'series',
@@ -317,19 +317,20 @@ export const getMWASScatterPlotData = (data, activeMetadataType) => {
         title: {
             text: 'Metadata-wide association study (MWAS)',
             textStyle: {
-                color: 'white',
+                color: '#333',
                 fontSize: 14,
                 fontWeight: 'normal',
                 fontStyle: 'italic',
             },
             left: 0,
-            top: 0,
-            show: false,
+            top: 10,
+            show: true,
         },
         grid: {
-            left: '7%',
-            right: '7%',
-            bottom: '7%',
+            left: 60,
+            right: 60,
+            top: 50,
+            bottom: 50,
             containLabel: true,
             show: false,
         },
@@ -361,6 +362,8 @@ export const getMWASScatterPlotData = (data, activeMetadataType) => {
         },
         tooltip: {
             trigger: 'item',
+            confine: true,
+            extraCssText: 'max-width: 400px; white-space: normal; word-break: break-all;',
             axisPointer: {
                 type: 'shadow',
             },
@@ -375,7 +378,7 @@ export const getMWASScatterPlotData = (data, activeMetadataType) => {
                 type: 'scatter',
                 label: {
                     show: false,
-                    color: 'white',
+                    color: '#333',
                 },
                 emphasis: {
                     focus: 'series',

--- a/frontend/src/features/Query/OnboardingMessage.tsx
+++ b/frontend/src/features/Query/OnboardingMessage.tsx
@@ -143,7 +143,7 @@ const OnbaordingMessage = () => {
             <Card
                 sx={{
                     borderWidth: 1,
-                    borderColor: 'rgba(255, 255, 255, 0.48)',
+                    borderColor: 'divider',
                     borderRadius: 8,
                     margin: 2,
                 }}
@@ -159,7 +159,7 @@ const OnbaordingMessage = () => {
                         alignItems: 'center',
                         alignContent: 'center',
                         borderWidth: 2,
-                        borderColor: 'rgba(255, 255, 255, 0.48)',
+                        borderColor: 'divider',
                         borderRadius: 8,
                         borderStyle: 'solid',
                         height: 80,

--- a/frontend/src/features/Query/QueryView.tsx
+++ b/frontend/src/features/Query/QueryView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { selectSidebarOpen, toggleSidebar, selectActiveQueryModule, selectPalmprintOnly } from '../../app/slice.ts';
+import { selectSidebarOpen, toggleSidebar, selectActiveQueryModule, selectPalmprintOnly, selectDarkMode } from '../../app/slice.ts';
 import { moduleConfig } from '../Module/constants.ts';
 
 import Box from '@mui/material/Box';
@@ -14,6 +14,7 @@ const QueryView = () => {
     const activeQueryModule = useSelector(selectActiveQueryModule);
     const sidebarOpen = useSelector(selectSidebarOpen);
     const palmprintOnly = useSelector(selectPalmprintOnly);
+    const darkMode = useSelector(selectDarkMode);
 
     return (
         <Modal
@@ -35,7 +36,7 @@ const QueryView = () => {
                             position: 'absolute',
                             top: 60,
                             left: 240,
-                            backgroundColor: '#252427',
+                            backgroundColor: darkMode ? '#252427' : '#FFF',
                         }}
                     >
                         {moduleConfig[activeQueryModule].queryBuilderDisplay === 'input' ? (

--- a/frontend/src/features/Query/SRAIdsInput.tsx
+++ b/frontend/src/features/Query/SRAIdsInput.tsx
@@ -161,7 +161,7 @@ const SRAIdsInput = ({ palmprintOnly }) => {
                         id='outlined-multiline-static'
                         multiline
                         rows={4}
-                        sx={{ backgroundColor: 'rgba(40, 40, 40, 0.3)' }}
+                        sx={{ backgroundColor: 'action.hover' }}
                         defaultValue={inputIdString}
                         onChange={(event) => handleIdsChange(event)}
                         helperText={'Enter search terms seperated by comma or whitespace'}

--- a/frontend/src/features/Query/SidePanel.tsx
+++ b/frontend/src/features/Query/SidePanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { setActiveQueryModule, toggleSidebar, selectSidebarOpen, selectActiveQueryModule } from '../../app/slice.ts';
+import { setActiveQueryModule, toggleSidebar, selectSidebarOpen, selectActiveQueryModule, selectDarkMode } from '../../app/slice.ts';
 import { moduleConfig, sectionConfig } from '../Module/constants.ts';
 
 import MenuList from '@mui/material/MenuList';
@@ -16,6 +16,7 @@ const SidePanel = () => {
     const dispatch = useDispatch();
     const sidebarOpen = useSelector(selectSidebarOpen);
     const sectionLayout = useSelector(selectActiveQueryModule);
+    const darkMode = useSelector(selectDarkMode);
 
     const onItemClick = (moduleKey: string) => {
         dispatch(setActiveQueryModule(moduleKey));
@@ -40,11 +41,14 @@ const SidePanel = () => {
                 '& .MuiDrawer-paper': {
                     width: drawerWidth,
                     boxSizing: 'border-box',
-                    backgroundColor: 'rgb(40, 40, 40)',
+                    backgroundColor: darkMode ? '#1E1E1E' : '#FFF',
+                    backgroundImage: 'none',
+                    boxShadow: 'none',
                     border: 'none',
                     overflow: 'hidden',
                 },
             }}
+        >
         >
             <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', mt: 0.5 }}>
                 <IconButton onClick={handleDrawerClose}>

--- a/frontend/src/features/Results/ResultsTable.tsx
+++ b/frontend/src/features/Results/ResultsTable.tsx
@@ -3,7 +3,8 @@ import { moduleConfig } from '../Module/constants.ts';
 import { handleIdKeyIrregularities } from '../../common/utils/queryHelpers.ts';
 
 import PagedTable from '../../common/PagedTable.tsx';
-import { useGetResultQuery, useGetCountsQuery } from '../../api/client.ts';
+import { useGetResultQuery, useGetCountsQuery, useLazyGetResultQuery } from '../../api/client.ts';
+import { exportToCSV } from '../../common/utils/exportHelpers.ts';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Skeleton from '@mui/material/Skeleton';
@@ -54,6 +55,34 @@ const ResultsTable = ({ identifiers, moduleKey, shouldSkipFetching }) => {
             skip: shouldSkipFetching,
         },
     );
+
+    const [triggerFetchAll] = useLazyGetResultQuery();
+
+    const handleExportAll = async () => {
+        const idColumn = moduleConfig[moduleKey].resultsIdColumn;
+        const totalRows = totalCount?.length ? totalCount[0]?.count : 0;
+        if (!totalRows || shouldSkipFetching) return;
+
+        const allData = await triggerFetchAll({
+            idColumn,
+            ids: identifiers
+                ? identifiers[handleIdKeyIrregularities(idColumn)].single
+                : [],
+            idRanges: identifiers
+                ? identifiers[handleIdKeyIrregularities(idColumn)].range
+                : [],
+            table: moduleConfig[moduleKey].resultsTable,
+            sortByColumn: idColumn,
+            sortByDirection: 'asc',
+            pageStart: 0,
+            pageEnd: totalRows,
+        }).unwrap();
+
+        if (allData?.length) {
+            const exportHeaders = Object.keys(allData[0]);
+            exportToCSV(allData, exportHeaders, 'table-export.csv');
+        }
+    };
 
     const onPageChange = (event: unknown, newPage: number) => {
         setPage(newPage);
@@ -110,6 +139,7 @@ const ResultsTable = ({ identifiers, moduleKey, shouldSkipFetching }) => {
                     total={totalCount?.length ? totalCount[0]?.count : 0}
                     rows={resultData}
                     headers={getTableHeaders(resultData)}
+                    onExportAll={handleExportAll}
                 />
             )}
         </>


### PR DESCRIPTION
New Features / 新功能:
- ExportButton component & exportHelpers utilities (PNG/CSV export)
- All ECharts charts support ~600 DPI PNG export with embedded titles
- Tables support one-click CSV export for all pages
- Cytoscape network graphs & MapLibre maps support PNG export
- Light/dark theme toggle button in toolbar (default: light mode)
- All components adapt to theme switching
- Exported images always use white background

Fixes / 修复:
- All hardcoded dark gray backgrounds replaced with theme-aware values
- ECharts text colors adapted for light theme
- Host bar plot Y-axis alignment fixed (alignWithLabel)
- MWAS scatter plot grid/tooltip overflow fixed
- Duplicate React/ECharts titles removed

<!--

Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.


1. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
2. Ensure you have added or ran the appropriate tests for your PR
-->


#### What this PR does / why we need it:


#### Additional documentation or notes for your reviewer

```docs

```