### PR TITLE
Add chart & table export buttons with white-background PNG/CSV / 添加图表…

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
                 "echarts": "^5.6.0",
                 "echarts-for-react": "^3.0.2",
                 "echarts-stat": "^1.2.0",
+                "html2canvas": "^1.4.1",
                 "markdown-to-jsx": "^7.7.1",
                 "pako": "^2.1.0",
                 "react": "^18.3.1",
@@ -39,6 +40,7 @@
                 "@types/node": "^20.14.1",
                 "@types/react": "^18.3.3",
                 "@types/react-dom": "^18.3.0",
+                "cross-env": "^10.1.0",
                 "eslint": "^8.57.0",
                 "prettier": "^3.3.0",
                 "react-scripts": "^5.0.1",
@@ -2625,6 +2627,12 @@
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
             "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
+        },
+        "node_modules/@epic-web/invariant": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+            "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+            "dev": true
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
@@ -6811,6 +6819,14 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "node_modules/base64-arraybuffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+            "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
         "node_modules/batch": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -7539,10 +7555,27 @@
                 "node": ">=10"
             }
         },
+        "node_modules/cross-env": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+            "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+            "dev": true,
+            "dependencies": {
+                "@epic-web/invariant": "^1.0.0",
+                "cross-spawn": "^7.0.6"
+            },
+            "bin": {
+                "cross-env": "dist/bin/cross-env.js",
+                "cross-env-shell": "dist/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -7608,6 +7641,14 @@
             },
             "peerDependencies": {
                 "postcss": "^8.4"
+            }
+        },
+        "node_modules/css-line-break": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+            "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+            "dependencies": {
+                "utrie": "^1.0.2"
             }
         },
         "node_modules/css-loader": {
@@ -10769,6 +10810,18 @@
                 "webpack": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/html2canvas": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+            "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+            "dependencies": {
+                "css-line-break": "^2.1.0",
+                "text-segmentation": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=8.0.0"
             }
         },
         "node_modules/htmlparser2": {
@@ -19137,6 +19190,14 @@
                 "node": ">=8"
             }
         },
+        "node_modules/text-segmentation": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+            "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+            "dependencies": {
+                "utrie": "^1.0.2"
+            }
+        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -19652,6 +19713,14 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/utrie": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+            "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+            "dependencies": {
+                "base64-arraybuffer": "^1.0.2"
             }
         },
         "node_modules/uuid": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
         "echarts": "^5.6.0",
         "echarts-for-react": "^3.0.2",
         "echarts-stat": "^1.2.0",
+        "html2canvas": "^1.4.1",
         "markdown-to-jsx": "^7.7.1",
         "pako": "^2.1.0",
         "react": "^18.3.1",
@@ -26,7 +27,7 @@
         "redux-query-sync": "^0.1.10"
     },
     "scripts": {
-        "start": "REACT_APP_USE_LAMBDA=true react-scripts start",
+        "start": "cross-env REACT_APP_USE_LAMBDA=true react-scripts start",
         "start-local": "react-scripts start",
         "build": "react-scripts build",
         "test": "react-scripts test",
@@ -60,6 +61,7 @@
         "@types/node": "^20.14.1",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
+        "cross-env": "^10.1.0",
         "eslint": "^8.57.0",
         "prettier": "^3.3.0",
         "react-scripts": "^5.0.1",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -84,6 +84,7 @@ export const {
     useGetCountsQuery,
     useGetIdentifiersQuery,
     useGetResultQuery,
+    useLazyGetResultQuery,
     useGetMWASQuery,
     useLazyGetSummaryTextQuery,
     useLazyGetHypothesisQuery,

--- a/frontend/src/common/BarPlot.tsx
+++ b/frontend/src/common/BarPlot.tsx
@@ -1,7 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import ReactEcharts from 'echarts-for-react';
+import ExportButton from '../common/ExportButton.tsx';
+import { exportEChartsToPNG } from '../common/utils/exportHelpers.ts';
 
-const BarPlot = ({ plotData = {}, styles = {}, onEvents = {}, imagePath = "" }) => {
+const BarPlot = ({ plotData = {}, styles = {}, onEvents = {}, imagePath = "", module = "" }) => {
+    const echartsRef = useRef<any>(null);
     const [imageDimensions, setImageDimensions] = useState({ width: 100, height: 100, padding: 20, maxCategoryLength: 0, loaded: false });
     const [options, setOptions] = useState({});
 
@@ -64,7 +67,19 @@ const BarPlot = ({ plotData = {}, styles = {}, onEvents = {}, imagePath = "" }) 
         initializeChart();
     }, [imagePath, imageDimensions.loaded, plotData]);
 
-    return <ReactEcharts option={options} style={styles} onEvents={onEvents} />;
+    return (
+        <div style={{ position: 'relative' }}>
+            <div style={{ position: 'absolute', right: 8, top: 8, zIndex: 10 }}>
+                <ExportButton
+                    onClick={() => {
+                        const instance = echartsRef.current?.getEchartsInstance();
+                        if (instance) exportEChartsToPNG(instance, `open-virome-${module || 'SRA'}-BarPlot.png`);
+                    }}
+                />
+            </div>
+            <ReactEcharts ref={echartsRef} option={options} style={styles} onEvents={onEvents} />
+        </div>
+    );
 };
 
 export default BarPlot;

--- a/frontend/src/common/ExportButton.tsx
+++ b/frontend/src/common/ExportButton.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import DownloadIcon from '@mui/icons-material/Download';
+
+interface ExportButtonProps {
+    onClick: () => void;
+    tooltip?: string;
+    size?: 'small' | 'medium' | 'large';
+}
+
+const ExportButton = ({ onClick, tooltip = 'Download', size = 'small' }: ExportButtonProps) => (
+    <Tooltip title={tooltip}>
+        <IconButton onClick={onClick} size={size} sx={{ color: '#CCC' }}>
+            <DownloadIcon fontSize={size} />
+        </IconButton>
+    </Tooltip>
+);
+
+export default ExportButton;

--- a/frontend/src/common/HistogramPlot.tsx
+++ b/frontend/src/common/HistogramPlot.tsx
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import ReactEcharts from 'echarts-for-react';
+import ExportButton from '../common/ExportButton.tsx';
+import { exportEChartsToPNG } from '../common/utils/exportHelpers.ts';
 
-const HistogramPlot = ({ plotData = {}, styles = {}, onEvents = {} }) => {
+const HistogramPlot = ({ plotData = {}, styles = {}, onEvents = {}, module = "" }) => {
+    const echartsRef = useRef<any>(null);
     const defaultConfig = {
         backgroundColor: 'transparent',
         textStyle: {
@@ -39,7 +42,19 @@ const HistogramPlot = ({ plotData = {}, styles = {}, onEvents = {} }) => {
         obj.barWidth = '101%';
     });
 
-    return <ReactEcharts option={options} style={styles} onEvents={onEvents} />;
+    return (
+        <div style={{ position: 'relative' }}>
+            <div style={{ position: 'absolute', right: 8, top: 8, zIndex: 10 }}>
+                <ExportButton
+                    onClick={() => {
+                        const instance = echartsRef.current?.getEchartsInstance();
+                        if (instance) exportEChartsToPNG(instance, `open-virome-${module || 'SRA'}-HistogramPlot.png`);
+                    }}
+                />
+            </div>
+            <ReactEcharts ref={echartsRef} option={options} style={styles} onEvents={onEvents} />
+        </div>
+    );
 };
 
 export default HistogramPlot;

--- a/frontend/src/common/MapLibreDeckGLMap.tsx
+++ b/frontend/src/common/MapLibreDeckGLMap.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import MdCopyAll from '@mui/icons-material/CopyAll';
 import MdOpenInNew from '@mui/icons-material/OpenInNew';
 import { deflate } from 'pako';
 import { isSimpleLayout } from '../common/utils/plotHelpers.ts';
 import { truncate } from '../common/utils/textFormatting.ts';
+import ExportButton from '../common/ExportButton.tsx';
+import { exportCanvasToPNG, exportElementToPNG } from '../common/utils/exportHelpers.ts';
 import {
     WWF_BIOMES,
     AMAZON_LOCATION_API_KEY,
@@ -454,13 +456,17 @@ const DeckGLRenderScatterplot: any = ({
     });
 };
 
-const MapLibreDeckGLMap = ({ identifiers, layout, palmprintOnly, style = {} }) => {
+const MapLibreDeckGLMap = ({ identifiers, layout, palmprintOnly, style = {}, module = "" }) => {
     style = {
         ...{ height: '100%', position: 'relative', width: '100%' },
         ...style,
     };
 
     const mapRef = useRef(null);
+    const mlglMapRef = useRef<any>(null);
+    const biomesRef = useRef<HTMLDivElement>(null);
+    const countriesRef = useRef<HTMLDivElement>(null);
+    const sOTUsRef = useRef<HTMLDivElement>(null);
     const [attributeName, setAttributeName] = useState('');
     const [attributeValue, setAttributeValue] = useState('');
     const [biomeID, setBiomeID] = useState('');
@@ -506,6 +512,7 @@ const MapLibreDeckGLMap = ({ identifiers, layout, palmprintOnly, style = {} }) =
                     AMAZON_LOCATION_API_KEY,
                 zoom: 0.8,
             });
+            mlglMapRef.current = mlglMap;
             mlglMap.dragRotate.disable();
             mlglMap.getCanvas().style.cursor = 'crosshair';
 
@@ -586,6 +593,23 @@ const MapLibreDeckGLMap = ({ identifiers, layout, palmprintOnly, style = {} }) =
         else setCountryRegionID('');
     }, [biomeID, countryID]);
 
+    const handleExport = useCallback(() => {
+        const canvas = mlglMapRef.current?.getCanvas();
+        if (canvas) exportCanvasToPNG(canvas, `open-virome-${module || 'Ecology'}-MapLibreDeckGLMap.png`);
+    }, [module]);
+
+    const handleExportBiomes = useCallback(() => {
+        if (biomesRef.current) exportElementToPNG(biomesRef.current, `open-virome-${module || 'Ecology'}-TopBiomes.png`);
+    }, [module]);
+
+    const handleExportCountries = useCallback(() => {
+        if (countriesRef.current) exportElementToPNG(countriesRef.current, `open-virome-${module || 'Ecology'}-TopCountries.png`);
+    }, [module]);
+
+    const handleExportSOTUs = useCallback(() => {
+        if (sOTUsRef.current) exportElementToPNG(sOTUsRef.current, `open-virome-${module || 'Ecology'}-TopSOTUs.png`);
+    }, [module]);
+
     const MapLibreDeckGLMapModeButton: any = ({ onClick, selected, text }) => (
         <div
             onClick={onClick}
@@ -609,7 +633,7 @@ const MapLibreDeckGLMap = ({ identifiers, layout, palmprintOnly, style = {} }) =
         <div style={style}>
             <div style={{ alignItems: 'flex-end', display: 'flex', padding: '0 6px 0 6px' }}>
                 <div style={{ flex: '1 0' }}>
-                    <div style={{ color: '#EEE', fontSize: '16px', fontWeight: 700 }}>
+                    <div style={{ color: '#333', fontSize: '16px', fontWeight: 700 }}>
                         {'Showing ' +
                             siteCount.toLocaleString() +
                             ' contigs, representing ' +
@@ -649,6 +673,7 @@ const MapLibreDeckGLMap = ({ identifiers, layout, palmprintOnly, style = {} }) =
                             selected={mapMode === 'SAMPLES'}
                             text='Samples'
                         />
+                        <ExportButton onClick={handleExport} />
                     </div>
                 )}
             </div>
@@ -963,7 +988,10 @@ const MapLibreDeckGLMap = ({ identifiers, layout, palmprintOnly, style = {} }) =
             </div>
             {!isSimpleLayout(layout) && (
                 <div style={{ display: 'flex', gap: '24px', margin: '16px 0 0 0', padding: '0 8px 0 8px' }}>
-                    <div style={{ flex: '1 0' }}>
+                    <div style={{ flex: '1 0', position: 'relative' }} ref={biomesRef}>
+                        <div style={{ position: 'absolute', right: 4, top: 0, zIndex: 10 }}>
+                            <ExportButton onClick={handleExportBiomes} />
+                        </div>
                         <div style={{ color: '#CCC', fontSize: '14px', fontWeight: 700 }}>Top Biomes</div>
                         <div
                             style={{ backgroundColor: '#CCC', height: '1px', margin: '4px 0 4px 0', width: '100%' }}
@@ -1055,7 +1083,10 @@ const MapLibreDeckGLMap = ({ identifiers, layout, palmprintOnly, style = {} }) =
                             </div>
                         )}
                     </div>
-                    <div style={{ flex: '1 0' }}>
+                    <div style={{ flex: '1 0', position: 'relative' }} ref={countriesRef}>
+                        <div style={{ position: 'absolute', right: 4, top: 0, zIndex: 10 }}>
+                            <ExportButton onClick={handleExportCountries} />
+                        </div>
                         <div style={{ color: '#CCC', fontSize: '14px', fontWeight: 700 }}>Top Countries</div>
                         <div
                             style={{ backgroundColor: '#CCC', height: '1px', margin: '4px 0 4px 0', width: '100%' }}
@@ -1150,7 +1181,10 @@ const MapLibreDeckGLMap = ({ identifiers, layout, palmprintOnly, style = {} }) =
                             </div>
                         )}
                     </div>
-                    <div style={{ flex: '1 0' }}>
+                    <div style={{ flex: '1 0', position: 'relative' }} ref={sOTUsRef}>
+                        <div style={{ position: 'absolute', right: 4, top: 0, zIndex: 10 }}>
+                            <ExportButton onClick={handleExportSOTUs} />
+                        </div>
                         <div style={{ color: '#CCC', fontSize: '14px', fontWeight: 700 }}>Top sOTUs</div>
                         <div
                             style={{ backgroundColor: '#CCC', height: '1px', margin: '4px 0 4px 0', width: '100%' }}
@@ -1238,7 +1272,7 @@ const MapLibreDeckGLMap = ({ identifiers, layout, palmprintOnly, style = {} }) =
 const MapLibreDeckGLMapCopyButton = ({ ...props }) => (
     <MdCopyAll
         style={{
-            color: '#FFF',
+            color: '#333',
             cursor: 'pointer',
             fontSize: '16px',
             userSelect: 'none',
@@ -1250,7 +1284,7 @@ const MapLibreDeckGLMapURLButton = ({ fontSize, ...props }) => {
     if (!fontSize) fontSize = '18px';
 
     return (
-        <a style={{ color: '#FFF', userSelect: 'none' }} target='_blank' {...props}>
+        <a style={{ color: '#333', userSelect: 'none' }} target='_blank' {...props}>
             <MdOpenInNew style={{ fontSize, verticalAlign: 'bottom' }} />
         </a>
     );

--- a/frontend/src/common/NetworkPlot.tsx
+++ b/frontend/src/common/NetworkPlot.tsx
@@ -1,13 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import cytoscape from 'cytoscape';
 import fcose from 'cytoscape-fcose';
 
 import CytoscapeComponent from 'react-cytoscapejs';
 import Box from '@mui/material/Box';
+import ExportButton from '../common/ExportButton.tsx';
+import { exportCytoscapeToPNG } from '../common/utils/exportHelpers.ts';
 
 cytoscape.use(fcose);
 
-const NetworkPlot = ({ plotData = [], onNodeClick, onEdgeClick }) => {
+const NetworkPlot = ({ plotData = [], onNodeClick, onEdgeClick, module = "" }) => {
     const [cy, setCy] = useState(null);
 
     useEffect(() => {
@@ -164,8 +166,15 @@ const NetworkPlot = ({ plotData = [], onNodeClick, onEdgeClick }) => {
         },
     ];
 
+    const handleExport = useCallback(() => {
+        if (cy) exportCytoscapeToPNG(cy, `open-virome-${module || 'Virome'}-NetworkPlot.png`);
+    }, [cy, module]);
+
     return (
-        <Box>
+        <Box sx={{ position: 'relative' }}>
+            <Box sx={{ position: 'absolute', right: 8, top: 8, zIndex: 10 }}>
+                <ExportButton onClick={handleExport} />
+            </Box>
             <CytoscapeComponent
                 cy={setCy}
                 stylesheet={stylesheet}

--- a/frontend/src/common/PagedTable.tsx
+++ b/frontend/src/common/PagedTable.tsx
@@ -10,6 +10,8 @@ import TableRow from '@mui/material/TableRow';
 import TableSortLabel from '@mui/material/TableSortLabel';
 import Paper from '@mui/material/Paper';
 import { visuallyHidden } from '@mui/utils';
+import ExportButton from '../common/ExportButton.tsx';
+import { exportToCSV } from '../common/utils/exportHelpers.ts';
 
 function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
     if (b[orderBy] < a[orderBy]) {
@@ -104,11 +106,12 @@ function EnhancedTableHead(props: EnhancedTableProps) {
     );
 }
 
-const PagedTable = ({ page = 0, rows = [], headers = [], total, onPageChange, pageRows = 10 }) => {
+const PagedTable = ({ page = 0, rows = [], headers = [], total, onPageChange, pageRows = 10, allRows = null, onExportAll = null, module = "" }) => {
     const [order, setOrder] = React.useState<Order>('asc');
     const [orderBy, setOrderBy] = React.useState('calories');
     const [dense, setDense] = React.useState(true);
     const [rowsPerPage, setRowsPerPage] = React.useState(pageRows);
+    const [exporting, setExporting] = React.useState(false);
 
     const onRequestSort = (event: React.MouseEvent<unknown>, property: keyof Data) => {
         const isAsc = orderBy === property && order === 'asc';
@@ -124,8 +127,32 @@ const PagedTable = ({ page = 0, rows = [], headers = [], total, onPageChange, pa
         [order, orderBy, page, rowsPerPage, rows],
     );
 
+    const hasAllData = allRows && allRows.length > 0;
+    const hasExportAllHandler = !!onExportAll;
+
+    const handleExport = React.useCallback(async () => {
+        if (onExportAll) {
+            setExporting(true);
+            try {
+                await onExportAll();
+            } finally {
+                setExporting(false);
+            }
+        } else if (hasAllData) {
+            exportToCSV(allRows, headers, `open-virome-${module || 'SRA'}-PagedTable.csv`);
+        } else {
+            exportToCSV(rows, headers, `open-virome-${module || 'SRA'}-PagedTable.csv`);
+        }
+    }, [rows, headers, allRows, hasAllData, onExportAll, module]);
+
     return (
         <Box sx={{ width: '100%', overflow: 'hidden' }}>
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 0.5 }}>
+                <ExportButton
+                    onClick={handleExport}
+                    tooltip={exporting ? 'Downloading...' : hasExportAllHandler || hasAllData ? 'Download all as CSV' : 'Download current page as CSV'}
+                />
+            </Box>
             <Paper sx={{ overflow: 'hidden' }}>
                 <TableContainer>
                     <Table aria-labelledby='tableTitle' size={dense ? 'small' : 'medium'}>

--- a/frontend/src/common/PolarBarPlot.tsx
+++ b/frontend/src/common/PolarBarPlot.tsx
@@ -1,23 +1,15 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import ReactEcharts from 'echarts-for-react';
+import ExportButton from '../common/ExportButton.tsx';
+import { exportEChartsToPNG } from '../common/utils/exportHelpers.ts';
 
-const PolarBarPlot = ({ plotData = {}, styles = {}, onEvents = {} }) => {
+const PolarBarPlot = ({ plotData = {}, styles = {}, onEvents = {}, module = "" }) => {
+    const echartsRef = useRef<any>(null);
     const defaultConfig = {
         backgroundColor: 'transparent',
-        textStyle: {
-            color: 'white',
-        },
-        subtextStyle: {
-            color: 'white',
-        },
         grid: {
             left: '-1%',
             borderColor: 'transparent',
-        },
-        legend: {
-            textStyle: {
-                color: 'white',
-            },
         },
         tooltip: {
             trigger: 'axis',
@@ -39,7 +31,7 @@ const PolarBarPlot = ({ plotData = {}, styles = {}, onEvents = {} }) => {
         Math.max(...plotData.dataset.source.map((d) => d.target), ...plotData.dataset.source.map((d) => d.control)) *
         1.1;
 
-    const options = {
+    const options: any = {
         ...defaultConfig,
         ...plotData,
         series: [
@@ -60,7 +52,19 @@ const PolarBarPlot = ({ plotData = {}, styles = {}, onEvents = {} }) => {
         },
     };
 
-    return <ReactEcharts option={options} style={styles} onEvents={onEvents} />;
+    return (
+        <div style={{ position: 'relative' }}>
+            <div style={{ position: 'absolute', right: 8, top: 8, zIndex: 10 }}>
+                <ExportButton
+                    onClick={() => {
+                        const instance = echartsRef.current?.getEchartsInstance();
+                        if (instance) exportEChartsToPNG(instance, `open-virome-${module || 'SRA'}-PolarBarPlot.png`);
+                    }}
+                />
+            </div>
+            <ReactEcharts ref={echartsRef} option={options} style={styles} onEvents={onEvents} />
+        </div>
+    );
 };
 
 export default PolarBarPlot;

--- a/frontend/src/common/ScatterPlot.tsx
+++ b/frontend/src/common/ScatterPlot.tsx
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import ReactEcharts from 'echarts-for-react';
+import ExportButton from '../common/ExportButton.tsx';
+import { exportEChartsToPNG } from '../common/utils/exportHelpers.ts';
 
-const ScatterPlot = ({ plotData = {}, styles = {}, onEvents = {} }) => {
+const ScatterPlot = ({ plotData = {}, styles = {}, onEvents = {}, module = "" }) => {
+    const echartsRef = useRef<any>(null);
     const defaultConfig = {
         backgroundColor: 'transparent',
         textStyle: {
@@ -36,7 +39,19 @@ const ScatterPlot = ({ plotData = {}, styles = {}, onEvents = {} }) => {
         ...plotData,
     };
 
-    return <ReactEcharts option={options} style={styles} onEvents={onEvents} />;
+    return (
+        <div style={{ position: 'relative' }}>
+            <div style={{ position: 'absolute', right: 8, top: 8, zIndex: 10 }}>
+                <ExportButton
+                    onClick={() => {
+                        const instance = echartsRef.current?.getEchartsInstance();
+                        if (instance) exportEChartsToPNG(instance, `open-virome-${module || 'Virome'}-ScatterPlot.png`);
+                    }}
+                />
+            </div>
+            <ReactEcharts ref={echartsRef} option={options} style={styles} onEvents={onEvents} />
+        </div>
+    );
 };
 
 export default ScatterPlot;

--- a/frontend/src/common/VirtualizedTable.tsx
+++ b/frontend/src/common/VirtualizedTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -6,9 +6,11 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import Paper from '@mui/material/Paper';
 import Checkbox from '@mui/material/Checkbox';
+import Box from '@mui/material/Box';
 import { TableVirtuoso, TableComponents } from 'react-virtuoso';
+import ExportButton from '../common/ExportButton.tsx';
+import { exportToCSV } from '../common/utils/exportHelpers.ts';
 
 interface Data {
     name: string;
@@ -37,8 +39,12 @@ const defaultColumns: ColumnData[] = [
 ];
 
 const VirtuosoTableComponents: TableComponents<Data> = {
-    Scroller: React.forwardRef<HTMLDivElement>((props, ref) => (
-        <TableContainer component={Paper} {...props} ref={ref} />
+    Scroller: React.forwardRef<HTMLDivElement>((props: any, ref) => (
+        <TableContainer
+            {...props}
+            ref={ref}
+            sx={{ boxShadow: 'none', backgroundImage: 'none', backgroundColor: 'transparent', ...(props.sx || {}) }}
+        />
     )),
     Table: (props) => <Table {...props} sx={{ borderCollapse: 'separate', tableLayout: 'fixed' }} />,
     TableHead,
@@ -46,7 +52,7 @@ const VirtuosoTableComponents: TableComponents<Data> = {
     TableBody: React.forwardRef<HTMLTableSectionElement>((props, ref) => <TableBody {...props} ref={ref} />),
 };
 
-const VirtualizedTable = ({ rows = [], columns = defaultColumns, onRowClick, searchBar }) => {
+const VirtualizedTable = ({ rows = [], columns = defaultColumns, onRowClick, searchBar, module = "" }) => {
     const disableSelectAll = (rows) => rows.length === 0 || rows.length > 100;
     const hasCheckedRows = (rows) => rows.length > 0 && rows.some((row) => row.selected);
 
@@ -54,7 +60,7 @@ const VirtualizedTable = ({ rows = [], columns = defaultColumns, onRowClick, sea
         const isChecked = !disableSelectAll(rows) && rows.length > 0 && rows.every((row) => row.selected);
         return (
             <TableRow>
-                <TableCell padding='checkbox' sx={{ width: 8, pl: 2, backgroundColor: '#121212' }}>
+                <TableCell padding='checkbox' sx={{ width: 8, pl: 2, backgroundColor: 'background.paper' }}>
                     <Checkbox
                         color='primary'
                         checked={isChecked}
@@ -153,15 +159,25 @@ const VirtualizedTable = ({ rows = [], columns = defaultColumns, onRowClick, sea
         sortRowsBySelected(rows);
     }, [rows.length]);
 
+    const columnKeys = columns.map((c) => c.dataKey as string);
+    const handleExport = useCallback(() => {
+        exportToCSV(rows, columnKeys, `open-virome-${module || 'filter'}-VirtualizedTable.csv`);
+    }, [rows, columnKeys, module]);
+
     return (
-        <Paper style={{ height: '75vh', width: '100%' }}>
+        <Box sx={{ position: 'relative' }}>
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 0.5 }}>
+                <ExportButton onClick={handleExport} tooltip="Download CSV" />
+            </Box>
+            <Box sx={{ height: '75vh', width: '100%' }}>
             <TableVirtuoso
                 data={rows}
                 components={VirtuosoTableComponents}
                 fixedHeaderContent={() => fixedHeaderContent(columns, rows, onSelectAllClick)}
                 itemContent={rowContent}
             />
-        </Paper>
+            </Box>
+        </Box>
     );
 };
 

--- a/frontend/src/common/utils/exportHelpers.ts
+++ b/frontend/src/common/utils/exportHelpers.ts
@@ -1,0 +1,59 @@
+const triggerDownload = (url: string, filename: string) => {
+    const link = document.createElement('a');
+    link.download = filename;
+    link.href = url;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+};
+
+export const exportEChartsToPNG = (instance: any, filename: string) => {
+    const url = instance.getDataURL({
+        type: 'png',
+        pixelRatio: 6,
+        backgroundColor: '#FFFFFF',
+    });
+    triggerDownload(url, filename);
+};
+
+export const exportCytoscapeToPNG = (cy: any, filename: string) => {
+    const url = cy.png({
+        full: true,
+        bg: '#FFFFFF',
+    });
+    triggerDownload(url, filename);
+};
+
+export const exportElementToPNG = async (element: HTMLElement, filename: string) => {
+    const html2canvas = (await import('html2canvas')).default;
+    const canvas = await html2canvas(element, {
+        backgroundColor: '#FFFFFF',
+        scale: 2,
+    });
+    triggerDownload(canvas.toDataURL('image/png'), filename);
+};
+
+export const exportCanvasToPNG = (canvas: HTMLCanvasElement, filename: string) => {
+    const url = canvas.toDataURL('image/png');
+    triggerDownload(url, filename);
+};
+
+export const exportToCSV = (rows: Record<string, any>[], headers: string[], filename: string) => {
+    const headerLine = headers.join(',');
+    const dataLines = rows.map((row) =>
+        headers
+            .map((h) => {
+                const val = row[h] ?? '';
+                const str = String(val);
+                return str.includes(',') || str.includes('"') || str.includes('\n')
+                    ? `"${str.replace(/"/g, '""')}"`
+                    : str;
+            })
+            .join(',')
+    );
+    const csv = [headerLine, ...dataLines].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    triggerDownload(url, filename);
+    URL.revokeObjectURL(url);
+};

--- a/frontend/src/features/Module/Virome/ViromeSummaryTable.tsx
+++ b/frontend/src/features/Module/Virome/ViromeSummaryTable.tsx
@@ -286,6 +286,8 @@ const ViromeSummaryTable = ({ activeModule, selectedItem, onClose, rows, maxWidt
                     rows={getPagedRows()}
                     headers={Object.keys(filteredRows[0])}
                     pageRows={getRowsPerPage()}
+                    allRows={filteredRows}
+                    module="Virome"
                 />
             </Box>
         );
@@ -303,7 +305,7 @@ const ViromeSummaryTable = ({ activeModule, selectedItem, onClose, rows, maxWidt
                 flexDirection: 'column',
                 width: '95%',
                 height: '100%',
-                backgroundColor: 'rgba(86, 86, 86, 0.6)',
+                backgroundColor: 'background.paper',
                 borderRadius: 2,
                 padding: 1.5,
             }}

--- a/frontend/src/features/Results/ResultsTable.tsx
+++ b/frontend/src/features/Results/ResultsTable.tsx
@@ -1,15 +1,24 @@
 import React, { useState } from 'react';
-import { moduleConfig } from '../Module/constants.ts';
+import { moduleConfig, sectionConfig } from '../Module/constants.ts';
 import { handleIdKeyIrregularities } from '../../common/utils/queryHelpers.ts';
 
 import PagedTable from '../../common/PagedTable.tsx';
-import { useGetResultQuery, useGetCountsQuery } from '../../api/client.ts';
+import { useGetResultQuery, useGetCountsQuery, useLazyGetResultQuery } from '../../api/client.ts';
+import { exportToCSV } from '../../common/utils/exportHelpers.ts';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Skeleton from '@mui/material/Skeleton';
 
+const ResultModuleMap: Record<string, string> = {};
+for (const [sectionKey, section] of Object.entries(sectionConfig)) {
+    for (const m of section.modules) {
+        ResultModuleMap[m] = sectionKey === 'palmdb' ? 'Virome' : sectionKey.charAt(0).toUpperCase() + sectionKey.slice(1);
+    }
+}
+
 const ResultsTable = ({ identifiers, moduleKey, shouldSkipFetching }) => {
     const [page, setPage] = useState(0);
+    const moduleName = ResultModuleMap[moduleKey] || 'Table';
 
     const {
         data: resultData,
@@ -54,6 +63,34 @@ const ResultsTable = ({ identifiers, moduleKey, shouldSkipFetching }) => {
             skip: shouldSkipFetching,
         },
     );
+
+    const [triggerFetchAll] = useLazyGetResultQuery();
+
+    const handleExportAll = async () => {
+        const idColumn = moduleConfig[moduleKey].resultsIdColumn;
+        const totalRows = totalCount?.length ? totalCount[0]?.count : 0;
+        if (!totalRows || shouldSkipFetching) return;
+
+        const allData = await triggerFetchAll({
+            idColumn,
+            ids: identifiers
+                ? identifiers[handleIdKeyIrregularities(idColumn)].single
+                : [],
+            idRanges: identifiers
+                ? identifiers[handleIdKeyIrregularities(idColumn)].range
+                : [],
+            table: moduleConfig[moduleKey].resultsTable,
+            sortByColumn: idColumn,
+            sortByDirection: 'asc',
+            pageStart: 0,
+            pageEnd: totalRows,
+        }).unwrap();
+
+        if (allData?.length) {
+            const exportHeaders = Object.keys(allData[0]);
+            exportToCSV(allData, exportHeaders, `open-virome-${moduleName}-PagedTable.csv`);
+        }
+    };
 
     const onPageChange = (event: unknown, newPage: number) => {
         setPage(newPage);
@@ -110,6 +147,8 @@ const ResultsTable = ({ identifiers, moduleKey, shouldSkipFetching }) => {
                     total={totalCount?.length ? totalCount[0]?.count : 0}
                     rows={resultData}
                     headers={getTableHeaders(resultData)}
+                    onExportAll={handleExportAll}
+                    module={moduleName}
                 />
             )}
         </>


### PR DESCRIPTION
…和表格导出功能

- New ExportButton component (MUI IconButton + Download icon + Tooltip)
- New exportHelpers utilities (ECharts PNG, Cytoscape PNG, Canvas PNG, CSV)
- All ECharts charts get PNG export button (~600 DPI, white background)
- Cytoscape network plot gets PNG export button (white background)
- MapLibreDeckGL map gets Canvas PNG export button
- PagedTable supports one-click full-dataset CSV export (server-side)
- PagedTable supports allRows prop for client-side full CSV export
- VirtualizedTable supports CSV export
- Export filenames include module name prefix (open-virome-*)
- ResultsTable dynamically maps moduleKey to module name for export filenames

<!--

Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.


1. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
2. Ensure you have added or ran the appropriate tests for your PR
-->


#### What this PR does / why we need it:


#### Additional documentation or notes for your reviewer

```docs

```